### PR TITLE
fix bot inactivity

### DIFF
--- a/src/core/telegrambot.py
+++ b/src/core/telegrambot.py
@@ -44,7 +44,10 @@ class TelegramBot(Bot):
     async def update_base_message(self):
         content = self.get_info_board()
         if content != self.base_message.text:
-            await self.base_message.edit_text(content)
+            failed = await self.base_message.edit_text(content)
+            if failed is True:
+                self.stop()
+                self.start()
 
     async def update_base_message_loop(self):
         while True:


### PR DESCRIPTION
Fixes #5 
^ The error wasn't actually that the but shut down, but rather the message that is edit couldn't be edited anymore, which is a telegram feature.

When the bot can't edit the message anymore, it just deletes it and sends a new one